### PR TITLE
Allow comparison of username or email for login until Microsoft fixes the core issue

### DIFF
--- a/AspNetCore.Identity.CosmosDb.Tests.Net7/Stores/CosmosUserStoreTests.cs
+++ b/AspNetCore.Identity.CosmosDb.Tests.Net7/Stores/CosmosUserStoreTests.cs
@@ -133,6 +133,21 @@ namespace AspNetCore.Identity.CosmosDb.Tests.Net7.Stores
         }
 
         [TestMethod()]
+        public async Task FindByNameEmailAsyncTest()
+        {
+            // Arrange
+            using var userStore = _testUtilities.GetUserStore();
+            var user = await GetMockRandomUserAsync(userStore);
+
+            // Act
+            var user1 = await userStore.FindByNameAsync(user.Email.ToUpper());
+
+            // Assert
+            Assert.IsNotNull(user);
+            Assert.AreEqual(user.UserName, user1.UserName);
+        }
+
+        [TestMethod()]
         public async Task GetEmailAsyncTest()
         {
             // Arrange

--- a/AspNetCore.Identity.CosmosDb/Stores/CosmosUserStore.cs
+++ b/AspNetCore.Identity.CosmosDb/Stores/CosmosUserStore.cs
@@ -1,17 +1,11 @@
 ﻿using AspNetCore.Identity.CosmosDb.Contracts;
-using AspNetCore.Identity.CosmosDb.Repositories;
-using IdentityModel;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.Azure.Cosmos;
-using Microsoft.Azure.Cosmos.Serialization.HybridRow;
 using Microsoft.EntityFrameworkCore;
 using System;
-using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -186,7 +180,7 @@ namespace AspNetCore.Identity.CosmosDb.Stores
                 throw new ArgumentNullException(nameof(normalizedUserName));
 
             return await _repo.Table<TUserEntity>()
-                .SingleOrDefaultAsync(_ => _.NormalizedUserName == normalizedUserName);
+                .SingleOrDefaultAsync(_ => _.NormalizedUserName == normalizedUserName || _.NormalizedEmail == normalizedUserName);
         }
 
         // <inheritdoc />


### PR DESCRIPTION
Referenced issue.

https://github.com/dotnet/aspnetcore/issues/44660

Not an ideal fix but I'm not sure what else to do short of just preventing users from changing username. 